### PR TITLE
Added `updateAvailableFrom` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 /build/*
 /yarn-error.log
 
+# CLAUDE
+CLAUDE.md
+
 # MISC FILES
 .cache
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 3.0.0 - Unreleased
+## 3.1.0 - 2026-06-15
+### Added
+- Added `updateAvailableFrom` function
+
+## 3.0.0 - 2025-12-15
 ### Added
 - Added support for SearchApi
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ the [workflowStatus model](https://docs.publiq.be/docs/uitdatabank/entry-api/ref
 $udb->updatePlaceWorkflowStatus($eventId, $data);
 ````
 
+#### Update the availableFrom date of an event
+
+The data passed should be an array, with fields that match
+the [availableFrom model](https://docs.publiq.be/docs/uitdatabank/entry-api/reference/operations/update-a-event-available-from).
+
+````php
+$udb->updateAvailableFrom($eventId, $data);
+````
+
 ---
 
 ## SearchAPI Initialization

--- a/src/EntryAPI.php
+++ b/src/EntryAPI.php
@@ -98,6 +98,11 @@ class EntryAPI
         return $this->api->post($data, '/events/' . $id . '/workflow-status', "PUT");
     }
 
+    public function updateAvailableFrom($id, $data)
+    {
+        return $this->api->post($data, '/events/' . $id . '/available-from', "PUT");
+    }
+
     public function updatePlaceWorkflowStatus($id, $data)
     {
         return $this->api->post($data, '/places/' . $id . '/workflow-status', "PUT");


### PR DESCRIPTION
### Description
Add the endpoint to update the `availableFrom` date.
API docs: https://docs.publiq.be/docs/uitdatabank/entry-api/reference/operations/update-a-event-available-from

### Reason for this change
We need to change the publication date of already existing events in UiT.